### PR TITLE
Fix multiple entity instantiation

### DIFF
--- a/server/static/child-entities.html
+++ b/server/static/child-entities.html
@@ -38,7 +38,7 @@
     <a-scene networked-scene="
       room: dev;
       debug: true;
-      adapter: wseasyrtc;
+      adapter: easyrtc;
     ">
       <a-assets>
 

--- a/server/static/child-entities.html
+++ b/server/static/child-entities.html
@@ -1,0 +1,131 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Dev Example — Networked-Aframe</title>
+    <meta name="description" content="Dev Example — Networked-Aframe">
+
+    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
+    <script src="/build.js"></script>
+
+    <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
+    <script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>
+    <script src="/js/spawn-in-circle.component.js"></script>
+
+    <script>
+      // Define custom schema for syncing avatar color, set by random-color
+      NAF.schemas.add({
+        template: '#avatar-template',
+        components: [
+          'position',
+          'rotation',
+          {
+            selector: '.head',
+            component: 'material',
+            property: 'color'
+          }
+        ]
+      });
+
+      // Called by Networked-Aframe when connected to server
+      function onConnect () {
+        console.log("onConnect", new Date());
+      }
+    </script>
+  </head>
+  <body>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
+    <a-scene networked-scene="
+      room: dev;
+      debug: true;
+      adapter: wseasyrtc;
+    ">
+      <a-assets>
+
+        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
+        <img id="sky" src="http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+
+        <!-- Templates -->
+
+        <!-- Avatar -->
+        <script id="avatar-template" type="text/html">
+          <a-entity class="avatar">
+            <a-sphere class="head"
+              color="#5985ff"
+              scale="0.45 0.5 0.4"
+              random-color
+            ></a-sphere>
+          </a-entity>
+        </script>
+
+        <script id="face-template" type="text/html">
+          <a-entity class="face"
+              position="0 0.05 0"
+            >
+            <a-sphere class="eye"
+              color="#efefef"
+              position="0.16 0.1 -0.35"
+              scale="0.12 0.12 0.12"
+            >
+              <a-sphere class="pupil"
+                color="#000"
+                position="0 0 -1"
+                scale="0.2 0.2 0.2"
+              ></a-sphere>
+            </a-sphere>
+            <a-sphere class="eye"
+              color="#efefef"
+              position="-0.16 0.1 -0.35"
+              scale="0.12 0.12 0.12"
+            >
+              <a-sphere class="pupil"
+                color="#000"
+                position="0 0 -1"
+                scale="0.2 0.2 0.2"
+              ></a-sphere>
+            </a-sphere>
+          </a-entity>
+        </script>
+
+        <script id="simple" type="text/html">
+          <a-sphere></a-sphere>
+        </script>
+
+        <!-- /Templates -->
+      </a-assets>
+
+      <a-entity id="player" networked="template:#avatar-template;showLocalTemplate:false;" camera="userHeight: 1.6" spawn-in-circle="radius:3" wasd-controls look-controls>
+        <a-entity id="face" networked="template:#face-template;showLocalTemplate:false;"></a-entity>
+      </a-entity>
+
+      <a-entity position="0 0 0"
+        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
+        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
+
+      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
+      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
+
+      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
+      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+    </a-scene>
+
+    <!-- GitHub Corner. -->
+    <a href="https://github.com/haydenjameslee/networked-aframe" class="github-corner">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+      </svg>
+    </a>
+    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+    </style>
+
+    <script>
+      // On mobile remove elements that are resource heavy
+      var isMobile = AFRAME.utils.device.isMobile();
+
+      if (isMobile) {
+        var particles = document.getElementById('particles');
+        particles.parentNode.removeChild(particles);
+      }
+    </script>
+  </body>
+</html>

--- a/src/NafIndex.js
+++ b/src/NafIndex.js
@@ -16,9 +16,6 @@ naf.physics = physics;
 naf.log = new NafLogger();
 naf.schemas = new Schemas();
 naf.version = "0.3.1";
-naf.isConnected = function() {
-  return !!naf.clientId;
-};
 
 var entities = new NetworkEntities();
 var connection = new NetworkConnection(entities);

--- a/src/NafIndex.js
+++ b/src/NafIndex.js
@@ -16,6 +16,9 @@ naf.physics = physics;
 naf.log = new NafLogger();
 naf.schemas = new Schemas();
 naf.version = "0.3.1";
+naf.isConnected = function() {
+  return !!naf.clientId;
+};
 
 var entities = new NetworkEntities();
 var connection = new NetworkConnection(entities);

--- a/src/NetworkConnection.js
+++ b/src/NetworkConnection.js
@@ -129,7 +129,7 @@ class NetworkConnection {
   dataChannelOpen(clientId) {
     NAF.log.write('Opened data channel from ' + clientId);
     this.activeDataChannels[clientId] = true;
-    this.entities.completeSync();
+    this.entities.completeSync(clientId);
 
     var evt = new CustomEvent('clientConnected', {detail: {clientId: clientId}});
     document.body.dispatchEvent(evt);

--- a/src/NetworkConnection.js
+++ b/src/NetworkConnection.js
@@ -10,8 +10,6 @@ class NetworkConnection {
 
     this.connectedClients = {};
     this.activeDataChannels = {};
-
-    this.connected = false;
   }
 
   setNetworkAdapter(adapter) {
@@ -58,7 +56,7 @@ class NetworkConnection {
   }
 
   onConnect(callback) {
-    if (this.connected) {
+    if (this.isConnected()) {
       callback();
     } else {
       document.body.addEventListener('connected', callback, false);
@@ -68,7 +66,6 @@ class NetworkConnection {
   connectSuccess(clientId) {
     NAF.log.write('Networked-Aframe Client ID:', clientId);
     NAF.clientId = clientId;
-    this.connected = true;
 
     var evt = new CustomEvent('connected', {'detail': { clientId: clientId }});
     document.body.dispatchEvent(evt);
@@ -76,7 +73,6 @@ class NetworkConnection {
 
   connectFailure(errorCode, message) {
     NAF.log.error(errorCode, "failure to connect");
-    this.connected = false;
   }
 
   occupantsReceived(occupantList) {
@@ -111,11 +107,11 @@ class NetworkConnection {
   }
 
   isConnected() {
-    return this.connected;
+    return !!NAF.clientId;
   }
 
   isMineAndConnected(clientId) {
-    return NAF.clientId == clientId;
+    return this.isConnected() && NAF.clientId === clientId;
   }
 
   isNewClient(clientId) {

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -141,8 +141,18 @@ class NetworkEntities {
     var children = this.childCache.getChildren(parentId);
     for (var i = 0; i < children.length; i++) {
       var childEntityData = children[i];
-      var childEntity = this.createRemoteEntity(childEntityData);
       var childId = childEntityData.networkId;
+      if (this.hasEntity(childId)) {
+        console.warn(
+          "Tried to instantiate entity multiple times",
+          childId,
+          childEntityData,
+          "Existing entity:",
+          this.getEntity(childId)
+        );
+        continue;
+      }
+      var childEntity = this.createRemoteEntity(childEntityData);
       this.createAndAppendChildren(childId, childEntity);
       parentEntity.appendChild(childEntity);
     }
@@ -166,10 +176,14 @@ class NetworkEntities {
     scene.appendChild(el);
   }
 
-  completeSync() {
+  completeSync(targetClientId) {
     for (var id in this.entities) {
       if (this.entities.hasOwnProperty(id)) {
-        this.entities[id].emit('syncAll', null, false);
+        this.entities[id].emit(
+          "syncAll",
+          { targetClientId, takeover: false },
+          false
+        );
       }
     }
   }

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -144,10 +144,10 @@ class NetworkEntities {
       var childId = childEntityData.networkId;
       if (this.hasEntity(childId)) {
         console.warn(
-          "Tried to instantiate entity multiple times",
+          'Tried to instantiate entity multiple times',
           childId,
           childEntityData,
-          "Existing entity:",
+          'Existing entity:',
           this.getEntity(childId)
         );
         continue;
@@ -180,7 +180,7 @@ class NetworkEntities {
     for (var id in this.entities) {
       if (this.entities.hasOwnProperty(id)) {
         this.entities[id].emit(
-          "syncAll",
+          'syncAll',
           { targetClientId, takeover: false },
           false
         );

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -46,7 +46,7 @@ AFRAME.registerComponent('networked', {
       // Only send the initial sync if we are connected. Otherwise this gets sent when the dataChannel is opened with each peer.
       // Note that this only works because the reliable messages are sent over a single websocket connection.
       // If they are sent over a different transport this check may need to change
-      if (NAF.isConnected()) {
+      if (NAF.connection.isConnected()) {
         this.syncAll();
       }
     }

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -41,9 +41,11 @@ AFRAME.registerComponent('networked', {
       this.registerEntity(data.networkId);
     }
 
-    if (this.data.owner === "") {
+    if (this.data.owner === '') {
       this.setNetworkIdWhenConnected();
-      // Only send the initial sync if we are connected. Otherwise this gets sent when the dataChannel is opened with each peer. Note that this only works because the reliable messages are sent over a single websocket connection. If they are sent over a different transport this check may need to change
+      // Only send the initial sync if we are connected. Otherwise this gets sent when the dataChannel is opened with each peer.
+      // Note that this only works because the reliable messages are sent over a single websocket connection.
+      // If they are sent over a different transport this check may need to change
       if (NAF.isConnected()) {
         this.syncAll();
       }
@@ -189,9 +191,9 @@ AFRAME.registerComponent('networked', {
 
   bindEvents: function() {
     var el = this.el;
-    el.addEventListener("sync", this.syncDirty);
-    el.addEventListener("syncAll", this.onSyncAll);
-    el.addEventListener("networkUpdate", this.networkUpdateHandler);
+    el.addEventListener('sync', this.syncDirty);
+    el.addEventListener('syncAll', this.onSyncAll);
+    el.addEventListener('networkUpdate', this.networkUpdateHandler);
   },
 
   pause: function() {
@@ -200,9 +202,9 @@ AFRAME.registerComponent('networked', {
 
   unbindEvents: function() {
     var el = this.el;
-    el.removeEventListener("sync", this.syncDirty);
-    el.removeEventListener("syncAll", this.onSyncAll);
-    el.removeEventListener("networkUpdate", this.networkUpdateHandler);
+    el.removeEventListener('sync', this.syncDirty);
+    el.removeEventListener('syncAll', this.onSyncAll);
+    el.removeEventListener('networkUpdate', this.networkUpdateHandler);
   },
 
   tick: function() {
@@ -228,9 +230,9 @@ AFRAME.registerComponent('networked', {
     var syncData = this.createSyncData(components, takeover);
     // console.error('syncAll', syncData, NAF.clientId);
     if (targetClientId) {
-      NAF.connection.sendDataGuaranteed(targetClientId, "u", syncData);
+      NAF.connection.sendDataGuaranteed(targetClientId, 'u', syncData);
     } else {
-      NAF.connection.broadcastDataGuaranteed("u", syncData);
+      NAF.connection.broadcastDataGuaranteed('u', syncData);
     }
     this.updateCache(components);
   },

--- a/tests/unit/NetworkEntities.test.js
+++ b/tests/unit/NetworkEntities.test.js
@@ -205,10 +205,7 @@ suite('NetworkEntities', function() {
       stub.onCall(2).returns(child2);
 
       entities.updateEntity('client', 'u', entityDataChild1);
-      entities.registerEntity('test-child-1', child1);
-
       entities.updateEntity('client', 'u', entityDataChild2);
-      entities.registerEntity('test-child-2', child2);
 
       assert.isFalse(entities.createRemoteEntity.calledWith(entityDataChild1), 'does not create child 1');
       assert.isFalse(entities.createRemoteEntity.calledWith(entityDataChild2), 'does not create child 2');
@@ -216,6 +213,7 @@ suite('NetworkEntities', function() {
       entities.updateEntity('client', 'u', entityDataParent);
       entities.registerEntity('test1', parent);
 
+      assert.equal(entities.createRemoteEntity.callCount, 3);
       assert.isTrue(entities.createRemoteEntity.calledWith(entityDataParent), 'creates parent');
       assert.isTrue(entities.createRemoteEntity.calledWith(entityDataChild1), 'creates child 1 after parent');
       assert.isTrue(entities.createRemoteEntity.calledWith(entityDataChild2), 'creates child 2 after parent');


### PR DESCRIPTION
WIP Fixes #41 by:

1. On opening a datachannel only send a sync packets to the user for which the channel was opened. Previously when a new user joins a room with N people in it, the new user would broadcast a sync packet for each of their entities N times. If those entities had children, there is a chance the parent component might get added to the child queue multiple times, and then get instantiated multiple times. This prevents that by only sending a single sync packet to each client.
2. If an entity is still attempted to be instantiated multiple times, don't, and log a warning.
