### PR TITLE
Fix firebase app

### DIFF
--- a/src/adapters/FirebaseWebRtcAdapter.js
+++ b/src/adapters/FirebaseWebRtcAdapter.js
@@ -328,7 +328,7 @@ class FirebaseWebRtcAdapter extends INetworkAdapter {
   getTimestamp(callback) {
     var firebase = this.app/*firebase*/;
     var ref = firebase.database().ref(this.getTimestampGenerationPath(this.localId));
-    ref.set(firebase.database.ServerValue.TIMESTAMP);
+    ref.set(this.firebase.database.ServerValue.TIMESTAMP);
     ref.once('value', function (data) {
       var timestamp = data.val();
       ref.remove();

--- a/src/adapters/FirebaseWebRtcAdapter.js
+++ b/src/adapters/FirebaseWebRtcAdapter.js
@@ -82,7 +82,7 @@ class FirebaseWebRtcAdapter extends INetworkAdapter {
 
     this.initFirebase(function(id) {
       self.localId = id;
-      var firebase = self.app; //this.firebase;
+      var firebase = self.app;
 
       // Note: assuming that data transfer via firebase realtime database
       //       is reliable and in order
@@ -258,7 +258,7 @@ class FirebaseWebRtcAdapter extends INetworkAdapter {
 
   authAnonymous(callback) {
     var self = this;
-    var firebase = this.app; //firebase;
+    var firebase = this.app;
 
     firebase.auth().signInAnonymously().catch(function (error) {
       console.error('FirebaseWebRtcInterface.authAnonymous: ' + error);
@@ -326,7 +326,7 @@ class FirebaseWebRtcAdapter extends INetworkAdapter {
   }
 
   getTimestamp(callback) {
-    var firebase = this.app/*firebase*/;
+    var firebase = this.app;
     var ref = firebase.database().ref(this.getTimestampGenerationPath(this.localId));
     ref.set(this.firebase.database.ServerValue.TIMESTAMP);
     ref.once('value', function (data) {

--- a/src/adapters/FirebaseWebRtcAdapter.js
+++ b/src/adapters/FirebaseWebRtcAdapter.js
@@ -79,10 +79,10 @@ class FirebaseWebRtcAdapter extends INetworkAdapter {
 
   connect() {
     var self = this;
-    var firebase = this.firebase;
 
     this.initFirebase(function(id) {
       self.localId = id;
+      var firebase = self.app; //this.firebase;
 
       // Note: assuming that data transfer via firebase realtime database
       //       is reliable and in order
@@ -173,7 +173,7 @@ class FirebaseWebRtcAdapter extends INetworkAdapter {
   sendDataGuaranteed(clientId, dataType, data) {
     var clonedData = JSON.parse(JSON.stringify(data));
     var encodedData = firebaseKeyEncode.deepEncode(clonedData);
-    this.firebase.database().ref(this.getDataPath(this.localId)).set({
+    this.app.database().ref(this.getDataPath(this.localId)).set({
       to: clientId,
       type: dataType,
       data: encodedData
@@ -220,11 +220,11 @@ class FirebaseWebRtcAdapter extends INetworkAdapter {
    */
 
   initFirebase(callback) {
-    this.firebase.initializeApp({
+    this.app = this.firebase.initializeApp({
       apiKey: this.apiKey,
       authDomain: this.authDomain,
       databaseURL: this.databaseURL
-    });
+    }, this.appId);
 
     this.auth(this.authType, callback);
   }
@@ -258,7 +258,7 @@ class FirebaseWebRtcAdapter extends INetworkAdapter {
 
   authAnonymous(callback) {
     var self = this;
-    var firebase = this.firebase;
+    var firebase = this.app; //firebase;
 
     firebase.auth().signInAnonymously().catch(function (error) {
       console.error('FirebaseWebRtcInterface.authAnonymous: ' + error);
@@ -326,7 +326,7 @@ class FirebaseWebRtcAdapter extends INetworkAdapter {
   }
 
   getTimestamp(callback) {
-    var firebase = this.firebase;
+    var firebase = this.app/*firebase*/;
     var ref = firebase.database().ref(this.getTimestampGenerationPath(this.localId));
     ref.set(firebase.database.ServerValue.TIMESTAMP);
     ref.once('value', function (data) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,16 +52,8 @@ module.exports.createNetworkId = function() {
 
 module.exports.delimiter = '---';
 
-function sanitizeKey(key) {
-  return key.replace(/\./g, '!').replace(/\#/g, '@').replace(/\[/g, '{').replace(/\]/g, '}'); 
-}
-
-function desanitizeKey(key) {
-  return key.replace(/\!/g, '.').replace(/\@/g, '#').replace(/\{/g, '[').replace(/\}/g, ']'); 
-}
-
 module.exports.childSchemaToKey = function(schema) {
-  var key = sanitizeKey(schema.selector || '')
+  var key = (schema.selector || '')
             + module.exports.delimiter
             + (schema.component || '')
             + module.exports.delimiter
@@ -71,7 +63,7 @@ module.exports.childSchemaToKey = function(schema) {
 
 module.exports.keyToChildSchema = function(key) {
   var splitKey = key.split(module.exports.delimiter, 3);
-  return { selector: desanitizeKey(splitKey[0]) || undefined, component: splitKey[1], property: splitKey[2] || undefined};
+  return { selector: splitKey[0] || undefined, component: splitKey[1], property: splitKey[2] || undefined};
 };
 
 module.exports.isChildSchemaKey = function(key) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,8 +52,16 @@ module.exports.createNetworkId = function() {
 
 module.exports.delimiter = '---';
 
+function sanitizeKey(key) {
+  return key.replace(/\./g, '!').replace(/\#/g, '@').replace(/\[/g, '{').replace(/\]/g, '}'); 
+}
+
+function desanitizeKey(key) {
+  return key.replace(/\!/g, '.').replace(/\@/g, '#').replace(/\{/g, '[').replace(/\}/g, ']'); 
+}
+
 module.exports.childSchemaToKey = function(schema) {
-  var key = (schema.selector || '')
+  var key = sanitizeKey(schema.selector || '')
             + module.exports.delimiter
             + (schema.component || '')
             + module.exports.delimiter
@@ -63,7 +71,7 @@ module.exports.childSchemaToKey = function(schema) {
 
 module.exports.keyToChildSchema = function(key) {
   var splitKey = key.split(module.exports.delimiter, 3);
-  return { selector: splitKey[0] || undefined, component: splitKey[1], property: splitKey[2] || undefined};
+  return { selector: desanitizeKey(splitKey[0]) || undefined, component: splitKey[1], property: splitKey[2] || undefined};
 };
 
 module.exports.isChildSchemaKey = function(key) {


### PR DESCRIPTION
The Firebase adapter was not using the specified app name (which becomes appId).  Instead, the default app name was always used, which could cause conflicts if actually trying to use more than one app per Firebase endpoint.

On the assumption that said behavior was unintentional, these changes correct that behavior.

(Note: the sanitization of the selector portion of the Firebase key was necessary in prior versions, but may have been replaced by different mechanisms in the latest, so not sure if that portion is still required.)